### PR TITLE
Update for api feature/6207

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@react-navigation/native-stack": "^7.1.14",
         "@reduxjs/toolkit": "^2.5.0",
         "axios": "^1.7.9",
-        "expo": "^52.0.35",
+        "expo": "^52.0.36",
         "expo-status-bar": "~2.0.1",
         "react": "18.3.1",
         "react-native": "^0.76.7",
@@ -2292,9 +2292,9 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "0.22.16",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.22.16.tgz",
-      "integrity": "sha512-a8Ulbnji9kFatnOtsWGCRs6nMUj9UNC0/WhE74HQdXGDGMn5Pl8eNe3cLMy9G54DdqAmEZmRZpgXmcudT78fEQ==",
+      "version": "0.22.17",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.22.17.tgz",
+      "integrity": "sha512-4VOGWoCINIlsQKL0Pl0kQpSs2xAaEPobJ/3Q3xHdtJrBj4S3IHrOyn6mUvubs4A4YySjiyZjlc4UG6GGwxzSsg==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
@@ -2306,11 +2306,11 @@
         "@expo/env": "~0.4.2",
         "@expo/image-utils": "^0.6.5",
         "@expo/json-file": "^9.0.2",
-        "@expo/metro-config": "~0.19.10",
+        "@expo/metro-config": "~0.19.11",
         "@expo/osascript": "^2.1.6",
         "@expo/package-manager": "^1.7.2",
         "@expo/plist": "^0.2.2",
-        "@expo/prebuild-config": "^8.0.27",
+        "@expo/prebuild-config": "^8.0.28",
         "@expo/rudder-sdk-node": "^1.1.1",
         "@expo/spawn-async": "^1.7.2",
         "@expo/ws-tunnel": "^1.0.1",
@@ -2440,14 +2440,14 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "9.0.15",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-9.0.15.tgz",
-      "integrity": "sha512-elKY/zIpAJ40RH26iwfyp+hwgeyPgIXX0SrCSOcjeJLsMsCmMac9ewvb+AN8y4k+N7m5lD/dMZupsaateKTFwA==",
+      "version": "9.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-9.0.16.tgz",
+      "integrity": "sha512-AnJzmFB7ztM0JZBn+Ut6BQYC2WeGDzfIhBZVOIPMQbdBqvwJ7TmFEsGTGSxdwU/VqJaJK2sWxyt1zbWkpIYCEA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-types": "^52.0.4",
-        "@expo/json-file": "~9.0.1",
-        "@expo/plist": "^0.2.1",
+        "@expo/config-types": "^52.0.5",
+        "@expo/json-file": "~9.0.2",
+        "@expo/plist": "^0.2.2",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
@@ -2474,9 +2474,9 @@
       }
     },
     "node_modules/@expo/config-types": {
-      "version": "52.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-52.0.4.tgz",
-      "integrity": "sha512-oMGrb2o3niVCIfjnIHFrOoiDA9jGb0lc3G4RI1UiO//KjULBaQr3QTBoKDzZQwMqDV1AgYgSr9mgEcnX3LqhIg==",
+      "version": "52.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-52.0.5.tgz",
+      "integrity": "sha512-AMDeuDLHXXqd8W+0zSjIt7f37vUd/BP8p43k68NHpyAvQO+z8mbQZm3cNQVAMySeayK2XoPigAFB1JF2NFajaA==",
       "license": "MIT"
     },
     "node_modules/@expo/config/node_modules/@babel/code-frame": {
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.11.10.tgz",
-      "integrity": "sha512-34ZwPjbnnD7KHSyceaxcLQbClCkYHbEp6wBDe+aqimvQw25m2LnliN1cMCVQnpOHkBFRTcbKlowby0fIxAm2bQ==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.11.11.tgz",
+      "integrity": "sha512-gNyn1KnAOpEa8gSNsYqXMTcq0fSwqU/vit6fP5863vLSKxHm/dNt/gm/uZJxrRZxKq71KUJWF6I7d3z8qIfq5g==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -2693,18 +2693,18 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.19.10.tgz",
-      "integrity": "sha512-/CtsMLhELJRJjAllM4EUnlPUAixn8Q2YhorKBa4uXZ6FvTEZWHJjqsXnQD39gWSEuAIVwLfJ1qgJi8666+dW2w==",
+      "version": "0.19.11",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.19.11.tgz",
+      "integrity": "sha512-XaobHTcsoHQdKEH7PI/DIpr2QiugkQmPYolbfzkpSJMplNWfSh+cTRjrm4//mS2Sb78qohtu0u2CGJnFqFUGag==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
         "@babel/parser": "^7.20.0",
         "@babel/types": "^7.20.0",
-        "@expo/config": "~10.0.9",
-        "@expo/env": "~0.4.1",
-        "@expo/json-file": "~9.0.1",
+        "@expo/config": "~10.0.10",
+        "@expo/env": "~0.4.2",
+        "@expo/json-file": "~9.0.2",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.1.0",
         "debug": "^4.3.2",
@@ -2850,16 +2850,16 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "8.0.27",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-8.0.27.tgz",
-      "integrity": "sha512-UFGOx4TfiT2gOde8RylwmXctp/WvqBQ4TN7z1YL0WWXfG9TWfO7HdsUnqQhGMW+CDDc7FOJMEo8q1a6xiikfYA==",
+      "version": "8.0.28",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-8.0.28.tgz",
+      "integrity": "sha512-SDDgCKKS1wFNNm3de2vBP8Q5bnxcabuPDE9Mnk9p7Gb4qBavhwMbAtrLcAyZB+WRb4QM+yan3z3K95vvCfI/+A==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~10.0.9",
+        "@expo/config": "~10.0.10",
         "@expo/config-plugins": "~9.0.15",
         "@expo/config-types": "^52.0.4",
-        "@expo/image-utils": "^0.6.4",
-        "@expo/json-file": "^9.0.1",
+        "@expo/image-utils": "^0.6.5",
+        "@expo/json-file": "^9.0.2",
         "@react-native/normalize-colors": "0.76.7",
         "debug": "^4.3.1",
         "fs-extra": "^9.0.0",
@@ -2961,9 +2961,10 @@
       }
     },
     "node_modules/@expo/ws-tunnel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.4.tgz",
-      "integrity": "sha512-spXCVXxbeKOe8YZ9igd+MDfXZe6LeDvFAdILijeTSG+XcxGrZLmqMWWkFKR0nV8lTWZ+NugUT3CoiXmEuKKQ7w=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.5.tgz",
+      "integrity": "sha512-Ta9KzslHAIbw2ZoyZ7Ud7/QImucy+K4YvOqo9AhGfUfH76hQzaffQreOySzYusDfW8Y+EXh0ZNWE68dfCumFFw==",
+      "license": "MIT"
     },
     "node_modules/@expo/xcpretty": {
       "version": "4.3.2",
@@ -7725,25 +7726,25 @@
       }
     },
     "node_modules/expo": {
-      "version": "52.0.35",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-52.0.35.tgz",
-      "integrity": "sha512-VagwS6MJbU0Eky18i4amkkSy7FTi0v31B0W+qoEcsU4x5OurA381rxw4qGsQE+8pmSD/Gf3DGb8ygJw+HoAsXw==",
+      "version": "52.0.36",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-52.0.36.tgz",
+      "integrity": "sha512-3QYoxz1+dW3IhBDuPUcw66K6GMUfwlZgXP42ypBT5d54X5AGPSo4Mk5RZxt6Buu+5K6F3qenml9B5snH/OvKIg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.22.16",
+        "@expo/cli": "0.22.17",
         "@expo/config": "~10.0.10",
         "@expo/config-plugins": "~9.0.15",
-        "@expo/fingerprint": "0.11.10",
-        "@expo/metro-config": "0.19.10",
+        "@expo/fingerprint": "0.11.11",
+        "@expo/metro-config": "0.19.11",
         "@expo/vector-icons": "^14.0.0",
         "babel-preset-expo": "~12.0.8",
-        "expo-asset": "~11.0.3",
-        "expo-constants": "~17.0.6",
-        "expo-file-system": "~18.0.10",
-        "expo-font": "~13.0.3",
-        "expo-keep-awake": "~14.0.2",
-        "expo-modules-autolinking": "2.0.7",
+        "expo-asset": "~11.0.4",
+        "expo-constants": "~17.0.7",
+        "expo-file-system": "~18.0.11",
+        "expo-font": "~13.0.4",
+        "expo-keep-awake": "~14.0.3",
+        "expo-modules-autolinking": "2.0.8",
         "expo-modules-core": "2.2.2",
         "fbemitter": "^3.0.0",
         "web-streams-polyfill": "^3.3.2",
@@ -7772,13 +7773,13 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.0.3.tgz",
-      "integrity": "sha512-vgJnC82IooAVMy5PxbdFIMNJhW4hKAUyxc5VIiAPPf10vFYw6CqHm+hrehu4ST1I4bvg5PV4uKdPxliebcbgLg==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.0.4.tgz",
+      "integrity": "sha512-CdIywU0HrR3wsW5c3n0cT3jW9hccZdnqGsRqY+EY/RWzJbDXtDfAQVEiFHO3mDK7oveUwrP2jK/6ZRNek41/sg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/image-utils": "^0.6.4",
-        "expo-constants": "~17.0.5",
+        "@expo/image-utils": "^0.6.5",
+        "expo-constants": "~17.0.7",
         "invariant": "^2.2.4",
         "md5-file": "^3.2.3"
       },
@@ -7789,13 +7790,13 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.0.6.tgz",
-      "integrity": "sha512-rl3/hBIIkh4XDkCEMzGpmY6kWj2G1TA4Mq2joeyzoFBepJuGjqnGl7phf/71sTTgamQ1hmhKCLRNXMpRqzzqxw==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.0.7.tgz",
+      "integrity": "sha512-sp5NUiV17I3JblVPIBDgoxgt7JIZS30vcyydCYHxsEoo+aKaeRYXxGYilCvb9lgI6BBwSL24sQ6ZjWsCWoF1VA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~10.0.9",
-        "@expo/env": "~0.4.1"
+        "@expo/config": "~10.0.10",
+        "@expo/env": "~0.4.2"
       },
       "peerDependencies": {
         "expo": "*",
@@ -7803,9 +7804,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "18.0.10",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.0.10.tgz",
-      "integrity": "sha512-+GnxkI+J9tOzUQMx+uIOLBEBsO2meyoYHxd87m9oT9M//BpepYqI1AvYBH8YM4dgr9HaeaeLr7z5XFVqfL8tWg==",
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.0.11.tgz",
+      "integrity": "sha512-yDwYfEzWgPXsBZHJW2RJ8Q66ceiFN9Wa5D20pp3fjXVkzPBDwxnYwiPWk4pVmCa5g4X5KYMoMne1pUrsL4OEpg==",
       "license": "MIT",
       "dependencies": {
         "web-streams-polyfill": "^3.3.2"
@@ -7816,9 +7817,10 @@
       }
     },
     "node_modules/expo-font": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.0.3.tgz",
-      "integrity": "sha512-9IdYz+A+b3KvuCYP7DUUXF4VMZjPU+IsvAnLSVJ2TfP6zUD2JjZFx3jeo/cxWRkYk/aLj5+53Te7elTAScNl4Q==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.0.4.tgz",
+      "integrity": "sha512-eAP5hyBgC8gafFtprsz0HMaB795qZfgJWqTmU0NfbSin1wUuVySFMEPMOrTkTgmazU73v4Cb4x7p86jY1XXYUw==",
+      "license": "MIT",
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -7828,18 +7830,19 @@
       }
     },
     "node_modules/expo-keep-awake": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.0.2.tgz",
-      "integrity": "sha512-71XAMnoWjKZrN8J7Q3+u0l9Ytp4OfhNAYz8BCWF1/9aFUw09J3I7Z5DuI3MUsVMa/KWi+XhG+eDUFP8cVA19Uw==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.0.3.tgz",
+      "integrity": "sha512-6Jh94G6NvTZfuLnm2vwIpKe3GdOiVBuISl7FI8GqN0/9UOg9E0WXXp5cDcfAG8bn80RfgLJS8P7EPUGTZyOvhg==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.0.7.tgz",
-      "integrity": "sha512-rkGc6a/90AC3q8wSy4V+iIpq6Fd0KXmQICKrvfmSWwrMgJmLfwP4QTrvLYPYOOMjFwNJcTaohcH8vzW/wYKrMg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.0.8.tgz",
+      "integrity": "sha512-DezgnEYFQYic8hKGhkbztBA3QUmSftjaNDIKNAtS2iGJmzCcNIkatjN2slFDSWjSTNo8gOvPQyMKfyHWFvLpOQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -8163,7 +8166,8 @@
     "node_modules/fontfaceobserver": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
-      "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg=="
+      "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -15761,9 +15765,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@react-navigation/native-stack": "^7.1.14",
     "@reduxjs/toolkit": "^2.5.0",
     "axios": "^1.7.9",
-    "expo": "^52.0.35",
+    "expo": "^52.0.36",
     "expo-status-bar": "~2.0.1",
     "react": "18.3.1",
     "react-native": "^0.76.7",

--- a/src/components/context/AuthContext.ts
+++ b/src/components/context/AuthContext.ts
@@ -6,7 +6,7 @@ import createDataContext from './createDataContext';
 const authReducer = (state, action) => {
   switch (action.type) {
     case 'signin':
-      return { ...state, isSignedIn: true, token: action.payload.token, user: action.payload.user };
+      return { ...state, isSignedIn: true, api_token: action.payload.api_token, refresh_token: action.payload.refresh_token, user: action.payload.user };
     case 'signout':
       return { ...state, isSignedIn: false, token: null };
     case 'update_user':
@@ -75,5 +75,5 @@ const tryLocalSignin = (dispatch) => async () => {
 export const { Provider, Context } = createDataContext(
   authReducer,
   { signin, signout, updateUser, tryLocalSignin },
-  { isSignedIn: false, token: null, user: null }
+  { isSignedIn: false, api_token: null, refresh_token: null, user: null }
 );

--- a/src/components/context/AuthContext.ts
+++ b/src/components/context/AuthContext.ts
@@ -60,14 +60,17 @@ const signout = (dispatch) => async () => {
 };
 
 const tryLocalSignin = (dispatch) => async () => {
-  const token = await AsyncStorage.getItem('auth_token');
+  const api_token = await AsyncStorage.getItem('api_token');
+  const refresh_token = await AsyncStorage.getItem('refresh_token');
+
   const user = await AsyncStorage.getItem('user');
 
-  console.log(token);
+  console.log(api_token);
+  console.log(refresh_token);
   console.log(user);
 
-  if (token && user) {
-    dispatch({ type: 'signin', payload: { token, user: JSON.parse(user) } });
+  if (api_token && refresh_token && user) {
+    dispatch({ type: 'signin', payload: { api_token, refresh_token, user: JSON.parse(user) } });
   } else {
     dispatch({ type: 'signout' });
   }

--- a/src/components/context/AuthContext.ts
+++ b/src/components/context/AuthContext.ts
@@ -8,7 +8,7 @@ const authReducer = (state, action) => {
     case 'signin':
       return { ...state, isSignedIn: true, api_token: action.payload.api_token, refresh_token: action.payload.refresh_token, user: action.payload.user };
     case 'signout':
-      return { ...state, isSignedIn: false, token: null };
+      return { ...state, isSignedIn: false, api_token: null, refresh_token: null };
     case 'update_user':
       return { ...state, user: action.payload };
     default:
@@ -51,7 +51,8 @@ const signin = (dispatch) => async (email, password) => {
 
 const signout = (dispatch) => async () => {
   try {
-    await AsyncStorage.removeItem('auth_token');
+    await AsyncStorage.removeItem('api_token');
+    await AsyncStorage.removeItem('refresh_token');
     dispatch({ type: 'signout' });
   } catch (err) {
     console.error('Error during signout:', err);

--- a/src/components/context/AuthContext.ts
+++ b/src/components/context/AuthContext.ts
@@ -31,15 +31,15 @@ const signin = (dispatch) => async (email, password) => {
   if (data) {
     const { api_token, refresh_token, user:{ id, display_name, email, refresh_token_expires_at, token_expires_at } } = data;
     try {
-      console.log(api_token)
-      console.log(refresh_token_expires_at)
-      // await AsyncStorage.setItem('auth_token', token);
-      // await AsyncStorage.setItem('user', JSON.stringify({ id, display_name, email }));
+      await AsyncStorage.setItem('api_token', api_token);
+      await AsyncStorage.setItem('refresh_token', refresh_token);
+      await AsyncStorage.setItem('user', JSON.stringify({ id, display_name, email, refresh_token_expires_at, token_expires_at }));
+
       console.log('User data stored in AsyncStorage' + ' Hello ' + display_name);
 
       dispatch({
         type: 'signin',
-        payload: { token, user: { id, display_name, email } },
+        payload: { api_token, refresh_token, user:{ id, display_name, email, refresh_token_expires_at, token_expires_at } },
       });
     } catch (storageError) {
       console.error('Error storing data in AsyncStorage:', storageError);

--- a/src/components/context/AuthContext.ts
+++ b/src/components/context/AuthContext.ts
@@ -29,10 +29,12 @@ const signin = (dispatch) => async (email, password) => {
   const data = await routeRequest('/api/v1/users/sign_in', { email, password }); // Sign-in first
 
   if (data) {
-    const { id, display_name, email, token } = data;
+    const { api_token, refresh_token, user:{ id, display_name, email, refresh_token_expires_at, token_expires_at } } = data;
     try {
-      await AsyncStorage.setItem('auth_token', token);
-      await AsyncStorage.setItem('user', JSON.stringify({ id, display_name, email }));
+      console.log(api_token)
+      console.log(refresh_token_expires_at)
+      // await AsyncStorage.setItem('auth_token', token);
+      // await AsyncStorage.setItem('user', JSON.stringify({ id, display_name, email }));
       console.log('User data stored in AsyncStorage' + ' Hello ' + display_name);
 
       dispatch({


### PR DESCRIPTION
<div align='center'>
Resolves #NaN
</div>

<br/>

### What does this PR solve or do?

Updates iOS apps intake for new `dual` token payload created in api [feature/6207](https://github.com/rubyforgood/casa/pull/6216) ( `api_token`, `refresh_token` )


#### What was edited, added, and or created?

- Updated [`src/components/context/AuthContext.ts`](https://github.com/ctc-casa-ios/ios-app/compare/update_for_api_feature/6207?expand=1#diff-ac8626c9cb8561d5a3c72eb7f600aea49ac10b5294fba82d195c2182c12bf740) with `new` format of `JSON` data's payload ( sign-in/sign-out, etc  )
- Updated `package.json` with latest `Expo` Version

### How is this tested?
None yet. The payload is still actively changing. 

Starting with a mock `HTTP` test for the `/src/authBase/routeRequest.ts` would be good as it's `foundational`.


### Screenshot/Video 📷


*Note:* Last `3` lines within my `terminal` below show the new `JSON `upon api `sign-in` to the `QA` server with...

Username as `volunteer1@example.com`
Password as `12345678`

As per [feature/6207](https://github.com/rubyforgood/casa/pull/6216) ( `api_token`, `refresh_token` ) tokens are `randomized` on each sign-in attempt and the `new` token expiry data is dynamically updated on token generation. 

![updated_input](https://github.com/user-attachments/assets/162ed25d-6938-464a-80b9-f55811f8a4ac)


### Feelings gif (optional)

What gif best describes your feelings working on this issue? <br />
![thumbs up](https://github.com/user-attachments/assets/8ac4ba60-faa8-4345-9b9c-0564222531f8)

