### PR TITLE
Feature/105: Implement sign out route to account screen

### DIFF
--- a/src/authBase/auth.ts
+++ b/src/authBase/auth.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const authApi = axios.create({
-  baseURL: 'https://casa-qa.herokuapp.com/', // Ruby for Good CASA QA
+  baseURL: 'https://c9bc-142-181-45-69.ngrok-free.app', // Ruby for Good CASA QA
   headers: {
     'Content-Type': 'application/json',
     Accept: 'application/json',

--- a/src/authBase/routeRequest.ts
+++ b/src/authBase/routeRequest.ts
@@ -2,14 +2,27 @@ import authApi from './auth';
 
 const routeRequest = async (route, payload) => {
   try {
-    const response = await authApi.post(route, payload);
+    if (route === '/api/v1/users/sign_out') {
+      const api_token = payload.api_token;
+      authApi.defaults.headers.common['Authorization'] = `Bearer ${api_token}`;
+      const response = await authApi.delete(route);
 
-    console.log(response.headers.toJSON());
-    console.log(response.status);
-    console.log(response.statusText);
-    console.log(response.data);
+      //console.log(response.headers.toJSON());
+      console.log(response.status);
+      console.log(response.statusText);
+      console.log(response.data);
 
-    return response.data;
+      return response.data;
+    } else if (route === '/api/v1/users/sign_in') {
+      const response = await authApi.post(route, payload);
+
+      //console.log(response.headers.toJSON());
+      console.log(response.status);
+      console.log(response.statusText);
+      console.log(response.data);
+
+      return response.data;
+    }
   } catch (err) {
     console.error('Error:', err.response);
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -10,10 +10,17 @@ interface Props {
   disabled?: boolean;
 }
 
-const Button: React.FC<Props> = ({ title, onPress, buttonStyle, textStyle, titleColor, disabled }) => {
+const Button: React.FC<Props> = ({
+  title,
+  onPress,
+  buttonStyle,
+  textStyle,
+  titleColor,
+  disabled,
+}) => {
   return (
-    <TouchableOpacity style={buttonStyle} onPress={onPress} disabled = {disabled}>
-      <Text style={textStyle} onPress={disabled ? undefined : onPress} disabled = {disabled}>
+    <TouchableOpacity style={buttonStyle} onPress={onPress} disabled={disabled}>
+      <Text style={textStyle} onPress={disabled ? undefined : onPress} disabled={disabled}>
         {title}
       </Text>
     </TouchableOpacity>

--- a/src/components/context/AuthContext.ts
+++ b/src/components/context/AuthContext.ts
@@ -8,7 +8,7 @@ const authReducer = (state, action) => {
     case 'signin':
       return { ...state, isSignedIn: true, api_token: action.payload.api_token, refresh_token: action.payload.refresh_token, user: action.payload.user };
     case 'signout':
-      return { ...state, isSignedIn: false, api_token: null, refresh_token: null };
+      return { ...state, isSignedIn: false, api_token: null, refresh_token: null, user: null };
     case 'update_user':
       return { ...state, user: action.payload };
     default:
@@ -51,8 +51,10 @@ const signin = (dispatch) => async (email, password) => {
 
 const signout = (dispatch) => async () => {
   try {
-    await AsyncStorage.removeItem('api_token');
-    await AsyncStorage.removeItem('refresh_token');
+    const api_token = await AsyncStorage.getItem('api_token');
+    const data = await routeRequest('/api/v1/users/sign_out', { api_token });
+    await AsyncStorage.multiRemove(['api_token', 'refresh_token', 'user']);
+    //to do: do something with the data
     dispatch({ type: 'signout' });
   } catch (err) {
     console.error('Error during signout:', err);

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -5,10 +5,18 @@ import tw from 'twrnc';
 
 import Button from '../components/Button';
 
-const AccountScreen = ({ navigation }) => {
-  const { state } = useContext(AuthContext);
+const AccountScreen = () => {
+  const { state, signout } = useContext(AuthContext);
 
   const { user } = state;
+
+  const handleSignOut = async () => {
+    try {
+      await signout();
+    } catch (err) {
+      console.error('Error during sign-out:', err);
+    }
+  };
 
   return (
     <View style={tw`flex items-center gap-3 flex-1 bg-[#d5d7da]`}>
@@ -23,7 +31,7 @@ const AccountScreen = ({ navigation }) => {
           textStyle={tw`text-xl font-bold text-white`}
           title="Sign out"
           titleColor="white"
-          onPress={console.log('For Sign out')}
+          onPress={handleSignOut}
         />
       </View>
     </View>


### PR DESCRIPTION
<div align='center'>
Resolves #105 
</div>

<br/>

### What does this PR solve or do?
When user's navigate to the account screen and press the sign out button, a delete request is sent along with the access token in it's authorization header to the server. The server will revoke the session by clearing the access and refresh tokens. On the client side, the user's info, access, refresh tokens are all cleared from both the global state and async storage. Finally, the user is automatically navigated back to the login screen.


#### What was edited, added, and or created?

- Auth Context - edited signout route to call delete and async storage
- routeRequest to handle multiple requests
-  account screen component to integrate sign out button with sign out dispatch function

### How is this tested?
tests will come soon once #106 is set up. For now look at demo and screenshots.


### Screenshot/Video 

https://github.com/user-attachments/assets/edfa1dc6-344e-4d3f-8e7b-fbb203c2683b

#### ngrok
![ngrok](https://github.com/user-attachments/assets/c7292af9-aeeb-4f64-a220-24f6b1ec2793)

#### client
![client](https://github.com/user-attachments/assets/02010dc2-2894-4ac4-8653-c1c9b4edd4a2)


#### server
![server](https://github.com/user-attachments/assets/a9078d56-5723-49e4-b107-2a89eefa4c04)


### Feelings gif (optional)

What gif best describes your feelings working on this issue? <br />
![dancing frogs](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExMHRvNnMxYTNsaHZmOXhuZDRuMnMzZmE0dmU4anRtanJqdm96ZjQ3cCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3UkvDtcUXyYvqmEsVa/giphy.gif)
